### PR TITLE
fix: string replace regex pattern

### DIFF
--- a/aws_wrapper/utils/rdsutils.py
+++ b/aws_wrapper/utils/rdsutils.py
@@ -163,10 +163,10 @@ class RdsUtils:
             return None
 
         if search(self.AURORA_CLUSTER_PATTERN, host):
-            return sub(self.AURORA_CLUSTER_PATTERN, "${instance}.cluster-${domain}", host)
+            return sub(self.AURORA_CLUSTER_PATTERN, r"\g<instance>.cluster-\g<domain>", host)
 
         if search(self.AURORA_CHINA_CLUSTER_PATTERN, host):
-            return sub(self.AURORA_CHINA_CLUSTER_PATTERN, "${instance}.cluster-${domain}", host)
+            return sub(self.AURORA_CHINA_CLUSTER_PATTERN, r"\g<instance>.cluster-\g<domain>", host)
 
         return None
 

--- a/unit_testing/test_rds_utils.py
+++ b/unit_testing/test_rds_utils.py
@@ -150,3 +150,15 @@ class TestRdsUtils(TestCase):
         target = RdsUtils()
 
         self.assertFalse(target.is_reader_cluster_dns(test_value))
+
+    def test_get_rds_cluster_host_url(self):
+        expected: str = "foo.cluster-xyz.us-west-1.rds.amazonaws.com"
+        expected2: str = "foo-1.cluster-xyz.us-west-1.rds.amazonaws.com.cn"
+
+        ro_endpoint: str = "foo.cluster-ro-xyz.us-west-1.rds.amazonaws.com"
+        china_ro_endpoint: str = "foo-1.cluster-ro-xyz.us-west-1.rds.amazonaws.com.cn"
+
+        target = RdsUtils()
+
+        self.assertEqual(expected, target.get_rds_cluster_host_url(ro_endpoint))
+        self.assertEqual(expected2, target.get_rds_cluster_host_url(china_ro_endpoint))


### PR DESCRIPTION
### Description

Fix bug where `rds_utils.get_rds_cluster_host_url('my-cluster.cluster-xyz.us-east-2.rds.amazonaws.com')` returns `'${instance}.cluster-${domain}'` instead of `my-cluster.cluster-xyz.us-east-2.rds.amazonaws.com`

### Additional Reviewers

<!--- Use this to tag extra reviewers for the PR. -->

### By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.