### PR TITLE
fix: incorrect failover error handling and logging error

### DIFF
--- a/aws_wrapper/errors.py
+++ b/aws_wrapper/errors.py
@@ -21,3 +21,15 @@ class AwsWrapperError(Error):
 
 class QueryTimeoutError(AwsWrapperError):
     __module__ = "aws_wrapper"
+
+
+class FailoverError(Error):
+    __module__ = "aws_wrapper"
+
+
+class TransactionResolutionUnknownError(FailoverError):
+    __module__ = "aws_wrapper"
+
+
+class FailoverSuccessError(FailoverError):
+    __module__ = "aws_wrapper"

--- a/aws_wrapper/failover_plugin.py
+++ b/aws_wrapper/failover_plugin.py
@@ -26,12 +26,12 @@ from typing import Any, Callable, Dict, List, Optional, Set
 
 from psycopg import OperationalError
 
-from aws_wrapper.errors import AwsWrapperError
+from aws_wrapper.errors import (AwsWrapperError, FailoverSuccessError,
+                                TransactionResolutionUnknownError)
 from aws_wrapper.host_list_provider import (AuroraHostListProvider,
                                             HostListProviderService)
 from aws_wrapper.hostinfo import HostAvailability, HostInfo, HostRole
-from aws_wrapper.pep249 import (Error, FailoverSuccessError,
-                                TransactionResolutionUnknownError)
+from aws_wrapper.pep249 import Error
 from aws_wrapper.plugin import Plugin, PluginFactory
 from aws_wrapper.reader_failover_handler import (ReaderFailoverHandler,
                                                  ReaderFailoverHandlerImpl)

--- a/aws_wrapper/pep249.py
+++ b/aws_wrapper/pep249.py
@@ -61,18 +61,6 @@ class InterfaceError(Error):
     __module__ = "aws_wrapper"
 
 
-class FailoverError(Error):
-    __module__ = "aws_wrapper"
-
-
-class TransactionResolutionUnknownError(FailoverError):
-    __module__ = "aws_wrapper"
-
-
-class FailoverSuccessError(FailoverError):
-    __module__ = "aws_wrapper"
-
-
 class DatabaseError(Error):
     __module__ = "aws_wrapper"
 

--- a/aws_wrapper/plugin_service.py
+++ b/aws_wrapper/plugin_service.py
@@ -390,7 +390,7 @@ class PluginServiceImpl(PluginService, HostListProviderService, CanReleaseResour
         return changes
 
     def release_resources(self):
-        logger.debug(Messages.get("PluginServiceImpl.ReleaseResources"))
+        logger.debug("[PluginServiceImpl] Releasing resources.")
         dialect = self.dialect
         try:
             if self.current_connection is not None and not dialect.is_closed(self.current_connection):

--- a/aws_wrapper/resources/messages.properties
+++ b/aws_wrapper/resources/messages.properties
@@ -99,7 +99,6 @@ Failover.UnableToConnectToWriter=Unable to establish SQL connection to the write
 PluginServiceImpl.NonEmptyAliases=[PluginServiceImpl] fill_aliases called when HostInfo already contains the following aliases: {}.
 PluginServiceImpl.FailedToRetrieveHostPort=[PluginServiceImpl] Could not retrieve Host:Port for connection. {}
 PluginServiceImpl.UpdateDialectNullConnection=[PluginServiceImpl] The plugin service attempted to update the current dialect but could not identify a connection to use.
-PluginServiceImpl.ReleaseResources=[PluginServiceImpl] Releasing resources.
 
 PropertiesUtils.NoHostDefined=[PropertiesUtils] PropertiesUtils.get_url was called but no host was defined in the properties. Please ensure you pass in a 'host' parameter when connecting.
 

--- a/aws_wrapper/wrapper.py
+++ b/aws_wrapper/wrapper.py
@@ -16,9 +16,9 @@ from logging import getLogger
 from typing import Any, Callable, Iterator, List, Optional, Union
 
 from aws_wrapper.connection_provider import DriverConnectionProvider
-from aws_wrapper.errors import AwsWrapperError
+from aws_wrapper.errors import AwsWrapperError, FailoverSuccessError
 from aws_wrapper.host_list_provider import AuroraHostListProvider
-from aws_wrapper.pep249 import Connection, Cursor, Error, FailoverSuccessError
+from aws_wrapper.pep249 import Connection, Cursor, Error
 from aws_wrapper.plugin import CanReleaseResources
 from aws_wrapper.plugin_service import (PluginManager, PluginService,
                                         PluginServiceImpl,

--- a/tests/unit/test_aurora_connection_tracker.py
+++ b/tests/unit/test_aurora_connection_tracker.py
@@ -30,13 +30,14 @@ from typing import TYPE_CHECKING
 
 import pytest
 
+from aws_wrapper.errors import FailoverError
+
 if TYPE_CHECKING:
     from aws_wrapper.pep249 import Connection
 
 from aws_wrapper.aurora_connection_tracker_plugin import \
     AuroraConnectionTrackerPlugin
 from aws_wrapper.hostinfo import HostInfo
-from aws_wrapper.pep249 import FailoverError
 from aws_wrapper.utils.properties import Properties
 
 

--- a/tests/unit/test_failover_plugin.py
+++ b/tests/unit/test_failover_plugin.py
@@ -18,6 +18,9 @@ from typing import TYPE_CHECKING
 
 import pytest
 
+from aws_wrapper.errors import (FailoverSuccessError,
+                                TransactionResolutionUnknownError)
+
 if TYPE_CHECKING:
     from aws_wrapper.dialect import Dialect
     from aws_wrapper.writer_failover_handler import WriterFailoverHandler
@@ -31,8 +34,7 @@ from aws_wrapper.failover_result import (ReaderFailoverResult,
                                          WriterFailoverResult)
 from aws_wrapper.host_list_provider import HostListProviderService
 from aws_wrapper.hostinfo import HostAvailability, HostInfo
-from aws_wrapper.pep249 import (Error, FailoverSuccessError,
-                                TransactionResolutionUnknownError)
+from aws_wrapper.pep249 import Error
 from aws_wrapper.utils.notifications import HostEvent
 from aws_wrapper.utils.properties import Properties, WrapperProperties
 


### PR DESCRIPTION
 fixes:
  - aurora_connection_tracker was catching the wrong failover exception, resulting idle connections not being invalidated after failover, this changes list move all custom driver errors to errors.py
   - release_resources may be called after tests ended to clean up remaining resources, resulting in I/O operations on closed files error

### Description

<!--- Body of this PR and the intended squashed commit message. Describe the change. -->

### By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
