### PR TITLE
fix: exception handling and syntax errors

### DIFF
--- a/aws_wrapper/aurora_connection_tracker_plugin.py
+++ b/aws_wrapper/aurora_connection_tracker_plugin.py
@@ -109,8 +109,7 @@ class OpenedConnectionTracker:
                 continue
 
             try:
-                conn: Connection = conn_reference()
-                conn.close()
+                conn_reference.close()
             except Exception:
                 # Swallow this exception, current connection should be useless anyway
                 pass

--- a/aws_wrapper/failover_plugin.py
+++ b/aws_wrapper/failover_plugin.py
@@ -67,7 +67,7 @@ class FailoverPlugin(Plugin):
         self._last_exception: Optional[Exception] = None
         self._rds_utils = RdsUtils()
         self._rds_url_type: RdsUrlType = self._rds_utils.identify_rds_type(self._properties.get("host"))
-        FailoverPlugin._SUBSCRIBED_METHODS.update(*self._plugin_service.network_bound_methods)
+        FailoverPlugin._SUBSCRIBED_METHODS.update(self._plugin_service.network_bound_methods)
 
     def init_host_provider(
             self,
@@ -345,7 +345,6 @@ class FailoverPlugin(Plugin):
             logger.debug(Messages.get_formatted("Failover.FailoverDisabled"))
             return False
 
-        # TODO: Consider whether this should belong to the is_network_exception logic
         if isinstance(ex, OperationalError):
             return True
 

--- a/aws_wrapper/resources/messages.properties
+++ b/aws_wrapper/resources/messages.properties
@@ -123,7 +123,7 @@ WriterFailoverHandler.TaskBEncounteredException=[WriterFailoverHandler] [TaskB] 
 WriterFailoverHandler.TaskAEncounteredException=[WriterFailoverHandler] [TaskA] encountered an exception: {}
 WriterFailoverHandler.StandaloneNode=[WriterFailoverHandler] [TaskB] Host {} is not yet connected to a cluster. The cluster is still being reconfigured.
 WriterFailoverHandler.AlreadyWriter=[WriterFailoverHandler] Current reader connection is actually a new writer connection.
-WriterFailoverHandler.CurrentReaderConnectionAndTopologyNone=[WriterFailoverHandler] Current reader connection and topology cannot be None.
+WriterFailoverHandler.CurrentTopologyNone=[WriterFailoverHandler] Current topology cannot be None.
 
 UnknownDialect.AbortConnection=[UnknownDialect] abort_connection was called, but the database dialect is unknown. A valid database dialect must be detected in order to abort a connection.
 

--- a/aws_wrapper/writer_failover_handler.py
+++ b/aws_wrapper/writer_failover_handler.py
@@ -203,13 +203,10 @@ class WriterFailoverHandlerImpl(WriterFailoverHandler):
 
     def connect_to_reader(self) -> None:
         while not self._timeout_event.is_set():
+            if self._current_topology is None:
+                raise AwsWrapperError(Messages.get("WriterFailoverHandler.CurrentTopologyNone"))
             try:
-                if self._current_topology is not None:
-                    conn_result: ReaderFailoverResult = self._reader_failover_handler.get_reader_connection(self._current_topology)
-                elif self._current_reader_connection is None:
-                    raise AwsWrapperError(Messages.get("WriterFailoverHandler.CurrentReaderConnectionAndTopologyNone"))
-                else:
-                    break
+                conn_result: ReaderFailoverResult = self._reader_failover_handler.get_reader_connection(self._current_topology)
 
                 # check if valid reader connection
                 if conn_result.is_connected and conn_result.connection is not None and conn_result.new_host is not None:


### PR DESCRIPTION
### Description

fixes:
- don't need to call obj() to get the reference when using WeakSet
- if current_topology is none and an AwsWrapperError is thrown during writer failover, this error will be ignored because it was thrown in the try catch block.

### By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
