### PR TITLE
chore: remove logging in release_resources

### DIFF
--- a/aws_wrapper/plugin_service.py
+++ b/aws_wrapper/plugin_service.py
@@ -406,7 +406,6 @@ class PluginServiceImpl(PluginService, HostListProviderService, CanReleaseResour
         return changes
 
     def release_resources(self):
-        logger.debug("[PluginServiceImpl] Releasing resources.")
         try:
             if self.current_connection is not None and not self.target_driver_dialect.is_closed(
                     self.current_connection):
@@ -610,8 +609,6 @@ class PluginManager(CanReleaseResources):
         Allows all connection plugins a chance to clean up any dangling resources
         or perform any last tasks before shutting down.
         """
-        logger.debug("[PluginManager] Releasing resources.")
-
         for plugin in self._plugins:
             if isinstance(plugin, CanReleaseResources):
                 plugin.release_resources()


### PR DESCRIPTION
### Description

Calling the logger after the application ended abruptly will result in the following error:
```
TestRunner > runTests(TestEnvironmentRequest) > integration.host.TestRunner.runTests(TestEnvironmentRequest)[1] STANDARD_ERROR
    --- Logging error ---
    Traceback (most recent call last):
      File "/usr/local/lib/python3.11/logging/__init__.py", line 1113, in emit
        stream.write(msg + self.terminator)
      File "/root/.cache/pypoetry/virtualenvs/aws-wrapper-9TtSrW0h-py3.11/lib/python3.11/site-packages/_pytest/capture.py", line 192, in write
        super().write(s)
    ValueError: I/O operation on closed file.
    Call stack:
      File "/app/aws_wrapper/wrapper.py", line 171, in __del__
        self.release_resources()
      File "/app/aws_wrapper/wrapper.py", line 166, in release_resources
        self._plugin_manager.release_resources()
      File "/app/aws_wrapper/plugin_service.py", line 613, in release_resources
        logger.debug("[PluginManager] Releasing resources.")
    Message: '[PluginManager] Releasing resources.'
    Arguments: ()
    --- Logging error ---
    Traceback (most recent call last):
      File "/usr/local/lib/python3.11/logging/__init__.py", line 1113, in emit
        stream.write(msg + self.terminator)
      File "/root/.cache/pypoetry/virtualenvs/aws-wrapper-9TtSrW0h-py3.11/lib/python3.11/site-packages/_pytest/capture.py", line 192, in write
        super().write(s)
    ValueError: I/O operation on closed file.
    Call stack:
      File "/app/aws_wrapper/wrapper.py", line 171, in __del__
        self.release_resources()
      File "/app/aws_wrapper/wrapper.py", line 168, in release_resources
        self._plugin_service.release_resources()
      File "/app/aws_wrapper/plugin_service.py", line 409, in release_resources
        logger.debug("[PluginServiceImpl] Releasing resources.")
    Message: '[PluginServiceImpl] Releasing resources.'
    Arguments: ()
```

This is caused by the logger attempting to perform I/O after the application has closed.

### By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
