### PR TITLE
chore: configure test framework to work on M1 Macs

### DIFF
--- a/tests/integration/host/src/test/java/integration/host/TestRunner.java
+++ b/tests/integration/host/src/test/java/integration/host/TestRunner.java
@@ -41,7 +41,7 @@ public class TestRunner {
      File reportFolder = new File("../container/reports");
      if (reportFolder.exists()) {
        File mergeReportsScript = new File("./scripts/merge_reports.py");
-       ProcessBuilder processBuilder = new ProcessBuilder("python", mergeReportsScript.getAbsolutePath());
+       ProcessBuilder processBuilder = new ProcessBuilder("python3", mergeReportsScript.getAbsolutePath());
        Process process = processBuilder.start();
        int exitCode = process.waitFor();
        assertEquals(0, exitCode, "An error occurred while attempting to run merge_reports.py");

--- a/tests/integration/host/src/test/java/integration/host/util/ContainerHelper.java
+++ b/tests/integration/host/src/test/java/integration/host/util/ContainerHelper.java
@@ -191,7 +191,7 @@ public class ContainerHelper {
                   builder -> appendExtraCommandsToBuilder.apply(
                       builder
                           .from(testContainerImageName)
-                          .run("apk", "add", "curl")
+                          .run("apk", "add", "curl", "gcc", "libc-dev", "libffi-dev")
                           .run("mkdir", "app")
                           .workDir("/app")
                           .run("curl", "-sSL", "https://install.python-poetry.org", "--output", "/app/poetry.py")


### PR DESCRIPTION
### Description

Integration tests fail on M1 Mac machines because the Python alpine images do not come with essential c libraries required to build Poetry.

Integration test run: https://github.com/awslabs/aws-advanced-python-wrapper/actions/runs/5982846423


### By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
