### PR TITLE
Upload individual reports instead of a consolidated report

### DIFF
--- a/tests/integration/host/src/test/java/integration/host/TestRunner.java
+++ b/tests/integration/host/src/test/java/integration/host/TestRunner.java
@@ -36,28 +36,30 @@ public class TestRunner {
     }
   }
 
-   @AfterAll
-   public static void cleanup() throws IOException, InterruptedException {
-     File reportFolder = new File("../container/reports");
-     if (reportFolder.exists()) {
-       File mergeReportsScript = new File("./scripts/merge_reports.py");
-       ProcessBuilder processBuilder = new ProcessBuilder("python3", mergeReportsScript.getAbsolutePath());
-       Process process = processBuilder.start();
-       int exitCode = process.waitFor();
-       assertEquals(0, exitCode, "An error occurred while attempting to run merge_reports.py");
-
-       // Delete individual reports in favor of consolidated report
-       File[] files = reportFolder.listFiles();
-       if (files != null) {
-         for (File f: files) {
-           if (!f.getName().equals("integration_tests.html") && !f.getName().equals("assets")) {
-             f.delete();
-           }
-         }
-       }
-       reportFolder.delete();
-     }
-   }
+//   TODO: uncomment once the pytest-html release candidate becomes official 
+//    to see if the consolidated report started working again
+//   @AfterAll
+//   public static void cleanup() throws IOException, InterruptedException {
+//     File reportFolder = new File("../container/reports");
+//     if (reportFolder.exists()) {
+//       File mergeReportsScript = new File("./scripts/merge_reports.py");
+//       ProcessBuilder processBuilder = new ProcessBuilder("python3", mergeReportsScript.getAbsolutePath());
+//       Process process = processBuilder.start();
+//       int exitCode = process.waitFor();
+//       assertEquals(0, exitCode, "An error occurred while attempting to run merge_reports.py");
+//
+//       // Delete individual reports in favor of consolidated report
+//       File[] files = reportFolder.listFiles();
+//       if (files != null) {
+//         for (File f: files) {
+//           if (!f.getName().equals("integration_tests.html") && !f.getName().equals("assets")) {
+//             f.delete();
+//           }
+//         }
+//       }
+//       reportFolder.delete();
+//     }
+//   }
 
   @TestTemplate
   public void runTests(TestEnvironmentRequest testEnvironmentRequest) throws Exception {


### PR DESCRIPTION
We recently upgraded to a pytest-html release candidate, since then the consolidated pytest report does not contain all the integration test results. We will temporarily upload individual reports for each test configuration instead. When the release candidate becomes official we can see if this issue is resolved and try to switch back to the consolidated report. 

### By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
