### PR TITLE
Change connect signature so that the connection string is optional

### DIFF
--- a/aws_wrapper/pep249.py
+++ b/aws_wrapper/pep249.py
@@ -33,7 +33,7 @@ aws_wrapper -- PEP249 base classes
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Callable, Union
 
 if TYPE_CHECKING:
     from types import TracebackType
@@ -102,9 +102,9 @@ class Connection:
 
     @staticmethod
     def connect(
+            target: Union[str, Callable],
             conninfo: str = "",
-            **kwargs
-    ) -> Any:
+            **kwargs: Any) -> Connection:
         ...
 
     def close(self) -> None:

--- a/aws_wrapper/utils/properties.py
+++ b/aws_wrapper/utils/properties.py
@@ -12,7 +12,7 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
-from typing import Dict, Optional, Union
+from typing import Any, Dict, Optional
 
 from aws_wrapper.errors import AwsWrapperError
 from aws_wrapper.utils.messages import Messages
@@ -142,7 +142,7 @@ class WrapperProperties:
 class PropertiesUtils:
 
     @staticmethod
-    def parse_properties(conn_info: str, **kwargs: Union[None, int, str]) -> Properties:
+    def parse_properties(conn_info: str, **kwargs: Any) -> Properties:
         props: Properties
         if conn_info == "":
             props = Properties()

--- a/aws_wrapper/wrapper.py
+++ b/aws_wrapper/wrapper.py
@@ -12,6 +12,8 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
+from __future__ import annotations
+
 from logging import getLogger
 from typing import Any, Callable, Iterator, List, Optional, Union
 
@@ -82,11 +84,10 @@ class AwsWrapperConnection(Connection, CanReleaseResources):
 
     @staticmethod
     def connect(
+            target: Union[str, Callable],
             conninfo: str = "",
-            target: Union[None, str, Callable] = None,
-            **kwargs: Union[None, int, str]
-    ) -> "AwsWrapperConnection":
-        if not target:
+            **kwargs: Any) -> AwsWrapperConnection:
+        if target is None or target == "":
             raise Error(Messages.get("Wrapper.RequiredTargetDriver"))
 
         # TODO: fix target str parsing functionality
@@ -130,7 +131,7 @@ class AwsWrapperConnection(Connection, CanReleaseResources):
         self._plugin_manager.execute(self.target_connection, "Connection.close",
                                      lambda: self.target_connection.close())
 
-    def cursor(self, **kwargs: Union[None, int, str]) -> "AwsWrapperCursor":
+    def cursor(self, **kwargs: Any) -> AwsWrapperCursor:
         _cursor = self.target_connection.cursor(**kwargs)
         return AwsWrapperCursor(self, self._plugin_manager, _cursor)
 
@@ -170,7 +171,7 @@ class AwsWrapperConnection(Connection, CanReleaseResources):
     def __del__(self):
         self.release_resources()
 
-    def __enter__(self: "AwsWrapperConnection") -> "AwsWrapperConnection":
+    def __enter__(self: AwsWrapperConnection) -> AwsWrapperConnection:
         return self
 
     def __exit__(self, exc_type: Any, exc_val: Any, exc_tb: Any) -> None:
@@ -211,15 +212,15 @@ class AwsWrapperCursor(Cursor):
         self._plugin_manager.execute(self.target_cursor, "Cursor.close",
                                      lambda: self.target_cursor.close())
 
-    def callproc(self, **kwargs: Union[None, int, str]):
+    def callproc(self, **kwargs: Any):
         return self._plugin_manager.execute(self.target_cursor, "Cursor.callproc",
                                             lambda: self.target_cursor.callproc(**kwargs))
 
     def execute(
             self,
             query: str,
-            **kwargs: Union[None, int, str]
-    ) -> "AwsWrapperCursor":
+            **kwargs: Any
+    ) -> AwsWrapperCursor:
         try:
             return self._plugin_manager.execute(self.target_cursor, "Cursor.execute",
                                                 lambda: self.target_cursor.execute(query, **kwargs), query, kwargs)
@@ -230,7 +231,7 @@ class AwsWrapperCursor(Cursor):
     def executemany(
             self,
             query: str,
-            **kwargs: Union[None, int, str]
+            **kwargs: Any
     ) -> None:
         self._plugin_manager.execute(self.target_cursor, "Cursor.executemany",
                                      lambda: self.target_cursor.executemany(query, **kwargs))
@@ -262,7 +263,7 @@ class AwsWrapperCursor(Cursor):
         return self._plugin_manager.execute(self.target_cursor, "Cursor.setoutputsize",
                                             lambda: self.target_cursor.setoutputsize(size, column))
 
-    def __enter__(self: "AwsWrapperCursor") -> "AwsWrapperCursor":
+    def __enter__(self: AwsWrapperCursor) -> AwsWrapperCursor:
         return self
 
     def __exit__(self, exc_type: Any, exc_val: Any, exc_tb: Any) -> None:

--- a/tests/integration/container/test_aurora_failover.py
+++ b/tests/integration/container/test_aurora_failover.py
@@ -67,8 +67,8 @@ class TestAuroraFailover:
         target_driver_connect = DriverHelper.get_connect_func(test_driver)
         initial_writer_id = aurora_utility.get_cluster_writer_instance_id()
 
-        with AwsWrapperConnection.connect(self._init_default_props(test_environment), target_driver_connect,
-                                          **props) as aws_conn:
+        with AwsWrapperConnection.connect(
+                target_driver_connect, self._init_default_props(test_environment), **props) as aws_conn:
             # Enable autocommit, otherwise each select statement will start a valid transaction.
             aws_conn.autocommit = True
 
@@ -92,8 +92,8 @@ class TestAuroraFailover:
         target_driver_connect = DriverHelper.get_connect_func(test_driver)
         initial_writer_id = aurora_utility.get_cluster_writer_instance_id()
 
-        with AwsWrapperConnection.connect(self._init_default_props(test_environment), target_driver_connect,
-                                          **props) as aws_conn:
+        with AwsWrapperConnection.connect(
+                target_driver_connect, self._init_default_props(test_environment), **props) as aws_conn:
             # Enable autocommit, otherwise each select statement will start a valid transaction.
             aws_conn.autocommit = True
 
@@ -117,8 +117,9 @@ class TestAuroraFailover:
 
         proxied_props["plugins"] = "failover,host_monitoring"
         with AwsWrapperConnection.connect(
+                target_driver_connect,
                 conn_utils.get_proxy_conn_string(instance.get_host()),
-                target_driver_connect, **proxied_props) as aws_conn:
+                **proxied_props) as aws_conn:
             # Enable autocommit, otherwise each select statement will start a valid transaction.
             aws_conn.autocommit = True
 
@@ -139,8 +140,8 @@ class TestAuroraFailover:
         target_driver_connect = DriverHelper.get_connect_func(test_driver)
         initial_writer_id = test_environment.get_writer().get_instance_id()
 
-        with AwsWrapperConnection.connect(self._init_default_props(test_environment), target_driver_connect,
-                                          **props) as conn, \
+        with AwsWrapperConnection.connect(
+                target_driver_connect, self._init_default_props(test_environment), **props) as conn, \
                 conn.cursor() as cursor_1:
             cursor_1.execute("DROP TABLE IF EXISTS test3_2")
             cursor_1.execute("CREATE TABLE test3_2 (id int not null primary key, test3_2_field varchar(255) not null)")
@@ -182,8 +183,8 @@ class TestAuroraFailover:
         target_driver_connect = DriverHelper.get_connect_func(test_driver)
         initial_writer_id = test_environment.get_writer().get_instance_id()
 
-        with AwsWrapperConnection.connect(self._init_default_props(test_environment), target_driver_connect,
-                                          **props) as conn:
+        with AwsWrapperConnection.connect(
+                target_driver_connect, self._init_default_props(test_environment), **props) as conn:
             # Enable autocommit, otherwise each select statement will start a valid transaction.
             conn.autocommit = True
 
@@ -233,11 +234,11 @@ class TestAuroraFailover:
 
         for i in range(self.IDLE_CONNECTIONS_NUM):
             idle_connections.append(
-                AwsWrapperConnection.connect(self._init_default_props(test_environment), target_driver_connect,
-                                             **props))
+                AwsWrapperConnection.connect(
+                    target_driver_connect, self._init_default_props(test_environment), **props))
 
-        with AwsWrapperConnection.connect(self._init_default_props(test_environment), target_driver_connect,
-                                          **props) as conn:
+        with AwsWrapperConnection.connect(
+                target_driver_connect, self._init_default_props(test_environment), **props) as conn:
 
             # Enable autocommit, otherwise each select statement will start a valid transaction.
             conn.autocommit = True
@@ -270,8 +271,8 @@ class TestAuroraFailover:
         nominated_writer_id = nominated_writer_instance_info.get_instance_id()
 
         props["plugins"] = "failover,host_monitoring"
-        with AwsWrapperConnection.connect(self._init_default_props(test_environment), target_driver_connect,
-                                          **props) as conn:
+        with AwsWrapperConnection.connect(
+                target_driver_connect, self._init_default_props(test_environment), **props) as conn:
             # Enable autocommit, otherwise each select statement will start a valid transaction.
             conn.autocommit = True
 

--- a/tests/integration/container/test_basic_connectivity.py
+++ b/tests/integration/container/test_basic_connectivity.py
@@ -43,7 +43,7 @@ class TestBasicConnectivity:
 
     def test_wrapper_connection(self, test_environment: TestEnvironment, test_driver: TestDriver, conn_utils):
         target_driver_connect = DriverHelper.get_connect_func(test_driver)
-        awsconn = AwsWrapperConnection.connect(conn_utils.get_conn_string(), target_driver_connect)
+        awsconn = AwsWrapperConnection.connect(target_driver_connect, conn_utils.get_conn_string())
         awscursor = awsconn.cursor()
         awscursor.execute("SELECT 1")
         records = awscursor.fetchall()
@@ -65,7 +65,7 @@ class TestBasicConnectivity:
     @enable_on_features([TestEnvironmentFeatures.NETWORK_OUTAGES_ENABLED])
     def test_proxied_wrapper_connection(self, test_environment: TestEnvironment, test_driver: TestDriver, conn_utils):
         target_driver_connect = DriverHelper.get_connect_func(test_driver)
-        awsconn = AwsWrapperConnection.connect(conn_utils.get_proxy_conn_string(), target_driver_connect)
+        awsconn = AwsWrapperConnection.connect(target_driver_connect, conn_utils.get_proxy_conn_string())
         awscursor = awsconn.cursor()
         awscursor.execute("SELECT 1")
         records = awscursor.fetchall()
@@ -82,7 +82,7 @@ class TestBasicConnectivity:
         ProxyHelper.disable_connectivity(instance.get_instance_id())
 
         try:
-            AwsWrapperConnection.connect(conn_utils.get_proxy_conn_string(), target_driver_connect)
+            AwsWrapperConnection.connect(target_driver_connect, conn_utils.get_proxy_conn_string())
 
             # Should not be here since proxy is blocking db connectivity
             assert False

--- a/tests/integration/container/test_iam_authentication.py
+++ b/tests/integration/container/test_iam_authentication.py
@@ -48,7 +48,7 @@ class TestAwsIamAuthentication:
         })
 
         with pytest.raises(AwsWrapperError):
-            AwsWrapperConnection.connect(connect_params, target_driver_connect)
+            AwsWrapperConnection.connect(target_driver_connect, connect_params)
 
     def test_iam_no_database_username(self, test_environment: TestEnvironment, test_driver: TestDriver, conn_utils):
         target_driver_connect = DriverHelper.get_connect_func(test_driver)
@@ -57,7 +57,7 @@ class TestAwsIamAuthentication:
         })
 
         with pytest.raises(AwsWrapperError):
-            AwsWrapperConnection.connect(connect_params, target_driver_connect)
+            AwsWrapperConnection.connect(target_driver_connect, connect_params)
 
     def test_iam_using_ip_address(self, test_environment: TestEnvironment, test_driver: TestDriver, conn_utils):
         target_driver_connect = DriverHelper.get_connect_func(test_driver)
@@ -109,7 +109,7 @@ class TestAwsIamAuthentication:
         return gethostbyname(hostname)
 
     def validate_connection(self, target_driver_connect: Callable, connect_params: str):
-        with AwsWrapperConnection.connect(connect_params, target_driver_connect) as conn, \
+        with AwsWrapperConnection.connect(target_driver_connect, connect_params) as conn, \
                 conn.cursor() as cursor:
             cursor.execute("SELECT now()")
             records = cursor.fetchall()

--- a/tests/integration/container/test_read_write_splitting.py
+++ b/tests/integration/container/test_read_write_splitting.py
@@ -71,7 +71,7 @@ class TestReadWriteSplitting:
     def test_connect_to_writer__switch_read_only(
             self, test_environment: TestEnvironment, test_driver: TestDriver, props, conn_utils, aurora_utils):
         target_driver_connect = DriverHelper.get_connect_func(test_driver)
-        conn = AwsWrapperConnection.connect(conn_utils.get_conn_string(), target_driver_connect, **props)
+        conn = AwsWrapperConnection.connect(target_driver_connect, conn_utils.get_conn_string(), **props)
         writer_id = aurora_utils.query_instance_id(conn)
 
         conn.read_only = True
@@ -99,7 +99,7 @@ class TestReadWriteSplitting:
         target_driver_connect = DriverHelper.get_connect_func(test_driver)
         reader_instance = test_environment.get_instances()[1]
         conn = AwsWrapperConnection.connect(
-            conn_utils.get_conn_string(reader_instance.get_host()), target_driver_connect, **props)
+            target_driver_connect, conn_utils.get_conn_string(reader_instance.get_host()), **props)
         reader_id = aurora_utils.query_instance_id(conn)
 
         conn.read_only = True
@@ -114,7 +114,7 @@ class TestReadWriteSplitting:
             self, test_environment: TestEnvironment, test_driver: TestDriver, props, conn_utils, aurora_utils):
         target_driver_connect = DriverHelper.get_connect_func(test_driver)
         conn = AwsWrapperConnection.connect(
-            conn_utils.get_conn_string(conn_utils.reader_cluster_host), target_driver_connect, **props)
+            target_driver_connect, conn_utils.get_conn_string(conn_utils.reader_cluster_host), **props)
         reader_id = aurora_utils.query_instance_id(conn)
 
         conn.read_only = True
@@ -128,7 +128,7 @@ class TestReadWriteSplitting:
     def test_set_read_only_false__read_only_transaction(
             self, test_environment: TestEnvironment, test_driver: TestDriver, props, conn_utils, aurora_utils):
         target_driver_connect = DriverHelper.get_connect_func(test_driver)
-        conn = AwsWrapperConnection.connect(conn_utils.get_conn_string(), target_driver_connect, **props)
+        conn = AwsWrapperConnection.connect(target_driver_connect, conn_utils.get_conn_string(), **props)
         writer_id = aurora_utils.query_instance_id(conn)
 
         conn.read_only = True
@@ -152,7 +152,7 @@ class TestReadWriteSplitting:
     def test_set_read_only_false_in_transaction(
             self, test_environment: TestEnvironment, test_driver: TestDriver, props, conn_utils, aurora_utils):
         target_driver_connect = DriverHelper.get_connect_func(test_driver)
-        conn = AwsWrapperConnection.connect(conn_utils.get_conn_string(), target_driver_connect, **props)
+        conn = AwsWrapperConnection.connect(target_driver_connect, conn_utils.get_conn_string(), **props)
         writer_id = aurora_utils.query_instance_id(conn)
 
         conn.read_only = True
@@ -176,7 +176,7 @@ class TestReadWriteSplitting:
     def test_set_read_only_true_in_transaction(
             self, test_environment: TestEnvironment, test_driver: TestDriver, props, conn_utils, aurora_utils):
         target_driver_connect = DriverHelper.get_connect_func(test_driver)
-        conn = AwsWrapperConnection.connect(conn_utils.get_conn_string(), target_driver_connect, **props)
+        conn = AwsWrapperConnection.connect(target_driver_connect, conn_utils.get_conn_string(), **props)
         writer_id = aurora_utils.query_instance_id(conn)
 
         cursor = conn.cursor()
@@ -195,7 +195,7 @@ class TestReadWriteSplitting:
     def test_set_read_only_true__all_readers_down(
             self, test_environment: TestEnvironment, test_driver: TestDriver, proxied_props, conn_utils, aurora_utils):
         target_driver_connect = DriverHelper.get_connect_func(test_driver)
-        conn = AwsWrapperConnection.connect(conn_utils.get_proxy_conn_string(), target_driver_connect, **proxied_props)
+        conn = AwsWrapperConnection.connect(target_driver_connect, conn_utils.get_proxy_conn_string(), **proxied_props)
         writer_id = aurora_utils.query_instance_id(conn)
 
         instance_ids = [instance.get_instance_id() for instance in test_environment.get_instances()]
@@ -218,7 +218,7 @@ class TestReadWriteSplitting:
     def test_set_read_only_true__closed_connection(
             self, test_environment: TestEnvironment, test_driver: TestDriver, props, conn_utils, aurora_utils):
         target_driver_connect = DriverHelper.get_connect_func(test_driver)
-        conn = AwsWrapperConnection.connect(conn_utils.get_conn_string(), target_driver_connect, **props)
+        conn = AwsWrapperConnection.connect(target_driver_connect, conn_utils.get_conn_string(), **props)
         conn.close()
 
         with pytest.raises(AwsWrapperError):
@@ -269,7 +269,7 @@ class TestReadWriteSplitting:
             proxied_props_with_failover, conn_utils, aurora_utils):
         target_driver_connect = DriverHelper.get_connect_func(test_driver)
         conn = AwsWrapperConnection.connect(
-            conn_utils.get_proxy_conn_string(), target_driver_connect, **proxied_props_with_failover)
+            target_driver_connect, conn_utils.get_proxy_conn_string(), **proxied_props_with_failover)
         original_writer_id = aurora_utils.query_instance_id(conn)
 
         instance_ids = [instance.get_instance_id() for instance in test_environment.get_instances()]

--- a/tests/unit/test_connection.py
+++ b/tests/unit/test_connection.py
@@ -36,9 +36,7 @@ def test_connection_basic():
             patch.object(PluginServiceImpl, "refresh_host_list"), \
             patch.object(PluginServiceImpl, "current_connection", None), \
             patch.object(PluginServiceImpl, "initial_connection_host_info", HostInfo("localhost")):
-        AwsWrapperConnection.connect(
-            conninfo,
-            connection_mock.connect)
+        AwsWrapperConnection.connect(connection_mock.connect, conninfo)
 
         connection_mock.connect.assert_called_with(host="localhost", dbname="postgres", user="postgres",
                                                    password="qwerty")


### PR DESCRIPTION
The MySQL driver connect function does not accept a connection string. Instead keyword arguments are used to configure the connection. Originally, the AwsWrapperConnection.connect function had the connection string as the first positional argument and a mandatory target driver connect function as the second positional argument. As a result, MySQL users would be required to arbitrarily supply "" as the connection string so that they could supply the mandatory target driver function as the second argument. By making the mandatory argument the first one, the connection string is now optional and does not have to be passed. 

### By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
