### PR TITLE
chore: remove sqlstate in AWS Errors as we are not using it

### DIFF
--- a/aws_wrapper/pep249.py
+++ b/aws_wrapper/pep249.py
@@ -48,14 +48,6 @@ class Warning(Exception):
 class Error(Exception):
     __module__ = "aws_wrapper"
 
-    def __init__(
-            self,
-            sqlstate: str = None,
-            *args: Any
-    ):
-        super().__init__(*args)
-        self._sqlstate: str = sqlstate
-
 
 class InterfaceError(Error):
     __module__ = "aws_wrapper"


### PR DESCRIPTION
### Description

Our custom errors are not thrown with the proper messaging. For instance:
Other errors:

```
        except e._NO_TRACEBACK as ex:
>           raise ex.with_traceback(None)
E           psycopg.OperationalError: connection failed: could not receive data from server: Connection refused
```

Our error:
```
            is_cached_token = (token_info and not token_info.is_expired())
            if not self._plugin_service.is_login_exception(error=e) or not is_cached_token:
>               raise AwsWrapperError(Messages.get_formatted("IamAuthPlugin.ConnectException", e)) from e
E               aws_wrapper.AwsWrapperError

```

Since we are not using sql_states, this PR just removes the custom constructor in our custom Errors class:
```
            is_cached_token = (token_info and not token_info.is_expired())
            if not self._plugin_service.is_login_exception(error=e) or not is_cached_token:
>               raise AwsWrapperError(Messages.get_formatted("IamAuthPlugin.ConnectException", e)) from e
E               aws_wrapper.AwsWrapperError: [IamAuthPlugin] Error occurred while opening a connection: connection failed: FATAL:  password authentication failed for user "pgadmin"
E               connection to server at "database-pg.cluster-cwpu2jclcwdc.us-east-2.rds.amazonaws.com" (18.190.128.93), port 5432 failed: FATAL:  password authentication failed for user "pgadmin"

```


### By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
