### PR TITLE
chore: add freeform log messaging

### DIFF
--- a/aws_wrapper/resources/messages.properties
+++ b/aws_wrapper/resources/messages.properties
@@ -87,6 +87,8 @@ FailoverPlugin.TransactionResolutionUnknownError=[Failover] Transaction resoluti
 FailoverPlugin.UnableToConnectToReader=[Failover] Unable to establish SQL connection to the reader instance.
 FailoverPlugin.UnableToConnectToWriter=[Failover] Unable to establish SQL connection to the writer instance.
 
+Freeform={}
+
 HostAvailabilityStrategy.InvalidInitialBackoffTime=[HostAvailabilityStrategy] Invalid value of {} for configuration parameter `host_availability_strategy_initial_backoff_time`. It must be an integer greater than 1.
 HostAvailabilityStrategy.InvalidMaxRetries=[HostAvailabilityStrategy] Invalid value of {} for configuration parameter `host_availability_strategy_max_retries`. It must be an integer greater than 1.
 

--- a/tests/integration/container/utils/aurora_test_utility.py
+++ b/tests/integration/container/utils/aurora_test_utility.py
@@ -152,6 +152,7 @@ class AuroraTestUtility:
             cluster_address = socket.gethostbyname(cluster_endpoint)
 
         self.logger.debug(
+            "Freeform",
             f"Finished failover from {initial_writer_id} in {(perf_counter_ns() - start) / 1_000_000}ms\n")
 
     def failover_cluster(self, cluster_id: Optional[str] = None) -> None:

--- a/tests/integration/container/utils/proxy_helper.py
+++ b/tests/integration/container/utils/proxy_helper.py
@@ -58,7 +58,7 @@ class ProxyHelper:
                                    stream="upstream",
                                    toxicity=1,
                                    attributes=attributes)
-        ProxyHelper.logger.debug("Disabled connectivity to " + proxy_info.proxy.name)
+        ProxyHelper.logger.debug("Freeform", "Disabled connectivity to " + proxy_info.proxy.name)
 
     @staticmethod
     def enable_all_connectivity():
@@ -89,4 +89,4 @@ class ProxyHelper:
         if up_stream is not None:
             proxy_info.proxy.destroy_toxic("UP-STREAM")
 
-        ProxyHelper.logger.debug("Enabled connectivity to " + proxy_info.proxy.name)
+        ProxyHelper.logger.debug("Freeform", "Enabled connectivity to " + proxy_info.proxy.name)


### PR DESCRIPTION
### Description

This PR allows the option for freeform log messages.

A recent change that introduced [log.py](https://github.com/awslabs/aws-advanced-python-wrapper/blob/main/aws_wrapper/utils/log.py), so that the first argument of logging methods takes in a message key, and it will fetch the formatted message from `messages.properties` for you.

So before, we would do something like `logger.debug(Messages.get_formatted("FailoverPlugin.Changes"), msg)`. But now we simply do `logger.debug("FailoverPlugin.Changes", msg)`.

But if you doing something like `logger.debug("SomeCustomMessage")` it will fail since it'll take `"SomeCustomMessages"` as a key, try to look for it in `messages.properties`, and then fail. 
Unfortunately this is what was happening to the integration tests.

So this PR is give us the option to do freeform messages like this `logger.debug("Freeform", "SomeCustomMessage")` in case we want/need to freeform log message.

### By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
