### PR TITLE
fix: integration test classes to use message keys

### DIFF
--- a/aws_wrapper/resources/messages.properties
+++ b/aws_wrapper/resources/messages.properties
@@ -203,8 +203,12 @@ TargetDriverDialectManager.UnknownDialectCode=[TargetDriverDialectManager] Unkno
 TargetDriverDialectManager.UseDialect=[TargetDriverDialectManager] Target driver dialect set to: {}, {}.
 
 Testing.CantParse=[Testing] Can't parse {}.
+Testing.DisabledConnectivity=[Testing] Disabled connectivity to {}.
+Testing.EnabledConnectivity=[Testing] Enabled connectivity to {}.
 Testing.EnvVarRequired=[Testing] Environment variable {} is required.
+Testing.FinishedFailover=[Testing] Finished failover from {} in {}ms.
 Testing.InstanceNotFound=[Testing] Instance {} not found.
+Testing.OpenConnectionFailed=[Testing] Open connection failed with exception: {}.
 Testing.ProxyNotFound=[Testing] Proxy for {} is not found.
 Testing.RequiredTestDriver=[Testing] testDriver is required.
 

--- a/tests/integration/container/test_failover_performance.py
+++ b/tests/integration/container/test_failover_performance.py
@@ -233,7 +233,7 @@ class TestPerformance:
                     conn_str,
                     **props)
             except Exception as e:
-                TestPerformance.logger.debug(f"Open connection failed with exception: {str(e)}")
+                TestPerformance.logger.debug("OpenConnectionFailed", str(e))
             connection_attempts += 1
 
         if conn is None:

--- a/tests/integration/container/utils/aurora_test_utility.py
+++ b/tests/integration/container/utils/aurora_test_utility.py
@@ -151,8 +151,7 @@ class AuroraTestUtility:
             sleep(1)
             cluster_address = socket.gethostbyname(cluster_endpoint)
 
-        self.logger.debug(
-            f"Finished failover from {initial_writer_id} in {(perf_counter_ns() - start) / 1_000_000}ms\n")
+        self.logger.debug("Testing.FinishedFailover", initial_writer_id, str((perf_counter_ns() - start) / 1_000_000))
 
     def failover_cluster(self, cluster_id: Optional[str] = None) -> None:
         if cluster_id is None:

--- a/tests/integration/container/utils/proxy_helper.py
+++ b/tests/integration/container/utils/proxy_helper.py
@@ -58,7 +58,7 @@ class ProxyHelper:
                                    stream="upstream",
                                    toxicity=1,
                                    attributes=attributes)
-        ProxyHelper.logger.debug("Disabled connectivity to " + proxy_info.proxy.name)
+        ProxyHelper.logger.debug("Testing.DisabledConnectivity", proxy_info.proxy.name)
 
     @staticmethod
     def enable_all_connectivity():
@@ -89,4 +89,4 @@ class ProxyHelper:
         if up_stream is not None:
             proxy_info.proxy.destroy_toxic("UP-STREAM")
 
-        ProxyHelper.logger.debug("Enabled connectivity to " + proxy_info.proxy.name)
+        ProxyHelper.logger.debug("Testing.EnabledConnectivity", proxy_info.proxy.name)


### PR DESCRIPTION
### Description

Some integration classes were not updated to use message keys, causing errors which are failing  integration tests. This PR moves the freeform log messages into message keys. 


### By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
