### PR TITLE
Fix flaky SlidingExpirationCache test

### DIFF
--- a/tests/unit/test_sliding_expiration_cache.py
+++ b/tests/unit/test_sliding_expiration_cache.py
@@ -30,7 +30,7 @@ def test_compute_if_absent():
     assert "a" == result2
     assert "a" == cache.get(1)
 
-    time.sleep(0.05)
+    time.sleep(0.07)  # Python may sleep slightly less than the given value
     result3 = cache.compute_if_absent(1, lambda _: "b", 5)
     assert "b" == result3
     assert "b" == cache.get(1)
@@ -54,7 +54,7 @@ def test_remove():
     result = cache.compute_if_absent("non_expired_item", lambda _: non_expired_item, 15_000_000_000)
     assert non_expired_item == result
 
-    time.sleep(0.05)
+    time.sleep(0.07)  # Python may sleep slightly less than the given value
     cache.remove("item_to_remove")
 
     assert cache.get("item_to_remove") is None


### PR DESCRIPTION
The tests in test_sliding_expiration_cache.py were occasionally failing. After some investigation, it appears that Python may not wait for the exact time you specify when calling time.sleep. This caused the tests to fail, so I've bumped up the sleep value slightly.

### By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
