### PR TITLE
chore: update release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,7 +16,9 @@ jobs:
       contents: read
       id-token: write
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
+        with:
+          ref: release
       - name: 'Set up Python 3.11'
         uses: actions/setup-python@v4
         with:


### PR DESCRIPTION

### Description

Specify the checkout reference so the workflow build the release from the `release` branch instead of `main`.

### By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
