### PR TITLE
fix: support MySQL v9

### DIFF
--- a/aws_advanced_python_wrapper/mysql_driver_dialect.py
+++ b/aws_advanced_python_wrapper/mysql_driver_dialect.py
@@ -131,8 +131,18 @@ class MySQLDriverDialect(DriverDialect):
 
         if isinstance(obj, CMySQLCursor):
             try:
-                if isinstance(obj._cnx, CMySQLConnection) or isinstance(obj._cnx, MySQLConnection):
-                    return obj._cnx
+                conn = None
+
+                if hasattr(obj, '_cnx'):
+                    conn = obj._cnx
+                elif hasattr(obj, '_connection'):
+                    conn = obj._connection
+                if conn is None:
+                    return None
+
+                if isinstance(conn, CMySQLConnection) or isinstance(conn, MySQLConnection):
+                    return conn
+
             except ReferenceError:
                 return None
 


### PR DESCRIPTION
### Description

MySQL v9 renames an internal variable from `_cnx` to `_connection`.

### By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
