### PR TITLE
fix: remove sqlalchemy as a supported dialect from docs

### DIFF
--- a/aws_advanced_python_wrapper/driver_dialect_codes.py
+++ b/aws_advanced_python_wrapper/driver_dialect_codes.py
@@ -13,7 +13,6 @@
 #  limitations under the License.
 
 class DriverDialectCodes:
-    SQLALCHEMY = "sqlalchemy"
     PSYCOPG = "psycopg"
     MYSQL_CONNECTOR_PYTHON = "mysql-connector-python"
     GENERIC = "generic"

--- a/docs/using-the-python-driver/DriverDialects.md
+++ b/docs/using-the-python-driver/DriverDialects.md
@@ -26,7 +26,6 @@ Driver Dialect codes specify which driver dialect class to use.
 |--------------------------|--------------------------|
 | `PSYCOPG`                | `psycopg`                |
 | `MYSQL_CONNECTOR_PYTHON` | `mysql-connector-python` |
-| `SQLALCHEMY`             | `sqlalchemy`             |
 | `GENERIC`                | `generic`                |
 
 ## Custom Driver Dialects


### PR DESCRIPTION
### Description

SQLAlchemy is not a supported driver dialect

### By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
