### PR TITLE
fix: fixing broken link in verify urls

### DIFF
--- a/tests/unit/test_verify_links.py
+++ b/tests/unit/test_verify_links.py
@@ -68,4 +68,4 @@ def test_verify_urls(urls_list: list):
         response = request("GET", url)
 
         assert "jdbc" not in url
-        assert response.status_code == 200
+        assert response.status_code == 200 or response.status_code == 202


### PR DESCRIPTION
### Description

Verify Urls test is failing because some links are returning a 202 response. 
202 should be accepted since it some sites use async processing and retrying multiple times may be rejected because of anti bot measures. 

Also invalid AWS pages return a false positive because it only checks that the webpage can be accessed but the actual webpage returned in a 404 page. 

### By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
