### PR TITLE
Add support for Python 3.12 and 3.13

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -29,7 +29,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.8", "3.9", "3.10", "3.11"]
+        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12", "3.13"]
         poetry-version: ["1.8.2"]
 
     steps:

--- a/README.md
+++ b/README.md
@@ -215,7 +215,7 @@ For all other questions, please use [GitHub discussions](https://github.com/awsl
 
 1. Set up your environment by following the directions in the [Development Guide](./docs/development-guide/DevelopmentGuide.md).
 2. To contribute, first make a fork of this project. 
-3. Make any changes on your fork. Make sure you are aware of the requirements for the project (e.g. do not require Python 3.7 if we are supporting Python 3.8 - 3.11 (inclusive)).
+3. Make any changes on your fork. Make sure you are aware of the requirements for the project (e.g. do not require Python 3.7 if we are supporting Python 3.8 - 3.13 (inclusive)).
 4. Create a pull request from your fork. 
 5. Pull requests need to be approved and merged by maintainers into the main branch. <br />
 

--- a/docs/GettingStarted.md
+++ b/docs/GettingStarted.md
@@ -4,7 +4,7 @@
 
 Before using the AWS Advanced Python Driver, you must install:
 
-- Python 3.8 - 3.11 (inclusive).
+- Python 3.8 - 3.13 (inclusive).
 - The AWS Advanced Python Driver.
 - Your choice of underlying Python driver. 
   - To use the wrapper with Aurora with PostgreSQL compatibility, install [Psycopg](https://github.com/psycopg/psycopg).

--- a/docs/development-guide/DevelopmentGuide.md
+++ b/docs/development-guide/DevelopmentGuide.md
@@ -1,7 +1,7 @@
 # Development Guide
 
 ### Setup
-Make sure you have Python 3.8 - 3.11 (inclusive) installed, along with your choice of underlying Python driver (see [minimum requirements](../GettingStarted.md#minimum-requirements)).
+Make sure you have Python 3.8 - 3.13 (inclusive) installed, along with your choice of underlying Python driver (see [minimum requirements](../GettingStarted.md#minimum-requirements)).
 
 Clone the AWS Advanced Python Driver repository:
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,6 +20,8 @@ classifiers = [
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
 ]
 
 [tool.poetry.dependencies]


### PR DESCRIPTION
## Summary
This PR adds support for Python 3.12 and 3.13 to the AWS Advanced Python Wrapper.

## Changes
- Updated `pyproject.toml` to include Python 3.12 and 3.13 classifiers
- Added Python 3.12 and 3.13 to the CI test matrix in GitHub Actions
- Updated documentation in README.md, GettingStarted.md, and DevelopmentGuide.md
- Regenerated `poetry.lock` to resolve dependency constraints

## Test Plan
- All existing tests should continue to pass
- CI will now test against Python 3.12 and 3.13 versions
- Verified no deprecated Python features are used that would break in newer versions

## Compatibility
This change maintains full backward compatibility with existing Python versions (3.8-3.11) while extending support to the latest stable Python releases.