### PR TITLE
chore: add timeout to tests and print stacktrace

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -1387,6 +1387,21 @@ pytest = ">=6.2.5"
 dev = ["pre-commit", "pytest-asyncio", "tox"]
 
 [[package]]
+name = "pytest-timeout"
+version = "2.4.0"
+description = "pytest plugin to abort hanging tests"
+optional = false
+python-versions = ">=3.7"
+groups = ["test"]
+files = [
+    {file = "pytest_timeout-2.4.0-py3-none-any.whl", hash = "sha256:c42667e5cdadb151aeb5b26d114aff6bdf5a907f176a007a30b940d3d865b5c2"},
+    {file = "pytest_timeout-2.4.0.tar.gz", hash = "sha256:7e68e90b01f9eff71332b25001f85c75495fc4e3a836701876183c4bcfd0540a"},
+]
+
+[package.dependencies]
+pytest = ">=7.0.0"
+
+[[package]]
 name = "python-dateutil"
 version = "2.9.0.post0"
 description = "Extensions to the standard Python datetime module"
@@ -2240,4 +2255,4 @@ type = ["pytest-mypy"]
 [metadata]
 lock-version = "2.1"
 python-versions = "^3.10.0"
-content-hash = "219c6ed169c74778a600c5881dc9b14885a8b15c041e76f4f557f6538f7302d3"
+content-hash = "5c9676388fe69de1cd60d813b75285505ccbc9e872168e83f9af0d7130d7cb75"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -63,6 +63,7 @@ mysql-connector-python = "^9.5.0"
 opentelemetry-exporter-otlp = "^1.22.0"
 opentelemetry-exporter-otlp-proto-grpc = "^1.22.0"
 opentelemetry-sdk-extension-aws = "^2.0.1"
+pytest-timeout = "^2.3.1"
 
 [tool.isort]
 sections = "FUTURE,STDLIB,THIRDPARTY,FIRSTPARTY,LOCALFOLDER"

--- a/tests/integration/host/src/test/java/integration/util/ContainerHelper.java
+++ b/tests/integration/host/src/test/java/integration/util/ContainerHelper.java
@@ -73,7 +73,8 @@ public class ContainerHelper {
         "--html=./tests/integration/container/reports/%s.html", primaryInfo);
     Long exitCode = execInContainer(container, consumer,
         "poetry", "run", "pytest", "-vvvvv", reportSetting, "-k", config.testFilter,
-        "-p", "no:logging", "--capture=tee-sys", testFolder);
+        "--timeout=600", "--tb=long", "--timeout-method=thread", "-p", "no:logging",
+        "--capture=tee-sys",testFolder);
 
     System.out.println("==== Container console feed ==== <<<<");
     assertEquals(0, exitCode, "Some tests failed.");


### PR DESCRIPTION
### Description
chore: add timeout to integration tests. The 600 second timeout is a timeout for a single test. If the test reaches this timeout, it will output the call stack. This is useful for debugging hanging tests.

### By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
