### PR TITLE
fix: allow numOfInstances=3 when passing in env variable

### DIFF
--- a/tests/integration/host/src/test/java/integration/host/TestEnvironmentProvider.java
+++ b/tests/integration/host/src/test/java/integration/host/TestEnvironmentProvider.java
@@ -132,12 +132,12 @@ public class TestEnvironmentProvider implements TestTemplateInvocationContextPro
               // Multi-AZ Instances supports only 1 instance
               continue;
             }
-            if (deployment == DatabaseEngineDeployment.AURORA && numOfInstances == 3) {
-              // Aurora supports clusters with 3 instances but running such tests is similar
-              // to running tests on 5-instance cluster.
-              // Let's save some time and skip tests for this configuration
-              continue;
-            }
+           if (deployment == DatabaseEngineDeployment.AURORA && numOfInstances == 3 && config.numInstances == null) {
+             // Aurora supports clusters with 3 instances but running such tests is similar
+             // to running tests on 5-instance cluster.
+             // Let's save some time and skip tests for this configuration
+             continue;
+           }
 
             for (TargetPythonVersion targetPythonVersion : TargetPythonVersion.values()) {
               if (targetPythonVersion == TargetPythonVersion.PYTHON_3_11 && config.excludePython311) {


### PR DESCRIPTION
### Description

Previously, if we pass NUM_INSTANCES=3 in the integ test framework, it would skip the tests. We should allow it if it is passed as an environment variable.


### By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
