### PR TITLE
chore: cleanup on test run.

### DIFF
--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -5,6 +5,7 @@ on:
   push:
     branches:
       - main
+      - fix/pg-integ-test-seg-fault
 
 permissions:
   id-token: write   # This is required for requesting the JWT
@@ -18,7 +19,7 @@ jobs:
       fail-fast: false
       matrix:
         python-version: [ "3.11", "3.12", "3.13"  ]
-        environment: [ "mysql", "pg" ]
+        environment: [ "pg" ]
 
     steps:
       - name: 'Clone repository'
@@ -72,7 +73,7 @@ jobs:
       fail-fast: false
       matrix:
         python-version: [ "3.11", "3.12", "3.13" ]
-        environment: [ "mysql", "pg" ]
+        environment: [ "pg" ]
 
     steps:
       - name: 'Clone repository'

--- a/tests/integration/container/conftest.py
+++ b/tests/integration/container/conftest.py
@@ -63,7 +63,7 @@ logger = Logger(__name__)
 
 def _reset_wrapper_state():
     """Reset all wrapper caches, thread pools, and global state.
-    
+
     This should be called after each test to ensure clean state and prevent
     background threads from interfering with subsequent tests.
     """
@@ -198,10 +198,10 @@ def pytest_runtest_teardown(item, nextitem):
 
 
 def pytest_sessionfinish(session, exitstatus):
-    # Enable all connectivity in case any helper threads are still trying to execute against a disabled host
+    # Enable all connectivity and wait in case any helper threads are still trying to execute against a disabled host
     ProxyHelper.enable_all_connectivity()
-    
-
+    _reset_wrapper_state()
+    sleep(10)
 
 def log_exit():
     print("Python program is exiting...")


### PR DESCRIPTION
### Description

This PR cleans up the wrapper state after every run.

Pg sometimes seg faults during the test, this usually happens when we end the test while the threads are stuck in a loop after failover. Cleaning it up before starting the new tests and waiting before ending the program may resolve this


### By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
