### PR TITLE
Fix integration tests for SQLAlchemy ORM

### DIFF
--- a/tests/integration/container/sqlalchemy/test_sqlalchemy_basic.py
+++ b/tests/integration/container/sqlalchemy/test_sqlalchemy_basic.py
@@ -42,6 +42,8 @@ class Base(DeclarativeBase):
 
 
 class TestModel(Base):
+    __test__ = False
+
     """Basic test model for SQLAlchemy ORM functionality"""
     __tablename__ = 'sqlalchemy_test_model'
 

--- a/tests/integration/container/sqlalchemy/test_sqlalchemy_plugins.py
+++ b/tests/integration/container/sqlalchemy/test_sqlalchemy_plugins.py
@@ -50,6 +50,8 @@ class Base(DeclarativeBase):
     pass
 
 class TestModel(Base):
+    __test__ = False
+
     """Basic test model for SQLAlchemy ORM functionality"""
     __tablename__ = 'sqlalchemy_test_model'
 
@@ -120,6 +122,8 @@ def _build_url(user, password, host, port, dbname, wrapper_plugins=None, **extra
     query_params = {}
     if wrapper_plugins:
         query_params['wrapper_plugins'] = wrapper_plugins
+    else:
+        query_params['wrapper_plugins'] = ''
     query_params['connect_timeout'] = str(extra_options.get('connect_timeout', 10))
     for k, v in extra_options.items():
         if k != 'connect_timeout':
@@ -268,7 +272,7 @@ class TestSqlAlchemyPlugins:
         Base.metadata.create_all(engine, tables=[
             TestModel.__table__, DataTypeModel.__table__,
             Author.__table__, Book.__table__
-        ])
+        ], checkfirst=False)
 
         models = {
             'TestModel': TestModel,


### PR DESCRIPTION
### Description

This fixes the failing integration tests for SQLAlchemy ORM plugin tests. It also fixes a couple of warnings being emitted from these tests and the basic SQLAlchemy ORM tests.

### By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
