### PR TITLE
docs: short-lived runtime guidance (stateless mode, Glue PySpark, executor limits)

### DIFF
--- a/docs/using-the-python-wrapper/NotForExecutors.md
+++ b/docs/using-the-python-wrapper/NotForExecutors.md
@@ -1,0 +1,88 @@
+# Not For Executors: When the Python Wrapper Doesn't Fit
+
+This page is the honest version of the "limitations" section. If you're considering using the AWS Advanced Python Wrapper inside Spark executors, AWS Lambda functions with very short timeouts, or any other short-lived per-task process, read this first.
+
+## The runtime assumption
+
+The wrapper's headline features — failover handling, host monitoring, read/write splitting, topology caching — were designed around a runtime that looks like this:
+
+- **One process**, long-lived (minutes to hours).
+- **A small number of connections**, each used for many transactions.
+- **Background threads are welcome** (host monitoring, async upgrade attempts).
+- **In-process caches pay off** because they're hit many times.
+
+This is the shape of an application server, an ECS task, a long-running EC2 process, a Glue Python Shell job, or a Lambda function with sustained warm-container reuse.
+
+This is **not** the shape of:
+
+- A Spark executor running a partition task (seconds, then gone).
+- A Glue PySpark `mapPartitions` / `foreachPartition` callback.
+- A Lambda function that opens and closes a connection per invocation with cold containers.
+- An AWS Batch container that runs one job and exits.
+
+## What breaks (or wastes resources) at executor scale
+
+### Host monitoring threads outlive their usefulness — but only barely
+
+The `host_monitoring` plugin spawns a background thread per connection that probes liveness. The thread takes some time to detect a problem — short by application standards, eternal by partition-task standards. A partition task that runs for 2 seconds gets zero benefit from a monitor that needs more than that to pronounce a host dead. You pay the thread spawn cost, the inter-thread coordination cost, the shutdown cost, and you get nothing.
+
+### Topology caches are per-process, so they get cold N times
+
+Each executor JVM/Python process has its own topology cache. A 100-executor job means 100 cold caches and 100 topology refresh queries against your cluster — within seconds of each other. From RDS's perspective this looks like a thundering herd. From your perspective, each executor pays the cache-warm latency on its first task.
+
+### Read/write splitting needs connection lifetime to amortize
+
+The `read_write_splitting` plugin's value is being able to flip a single connection between writer and reader as your code switches between writes and reads. That assumes the connection will see many such flips. In a partition task, you connect, you do one thing (write OR read, rarely both), you disconnect. The plugin's machinery never gets used.
+
+### Failover transparent reconnection conflicts with task-retry semantics
+
+In stateful mode, when the wrapper sees failover, it transparently reconnects you to the new writer and raises `FailoverSuccessError` so you can retry your transaction. That's the right behavior in a long-lived process — your connection object is salvaged, your session state is mostly retained, and you re-run a transaction.
+
+In a Spark task, this is the wrong layer. The task is going to fail anyway (Spark needs the exception to count toward `task.maxFailures`), the executor is going to retry on a fresh connection anyway, and the new connection will route to the new writer via DNS anyway. The wrapper's transparent-reconnect code path is doing work that's about to be thrown away.
+
+### Connections aren't shareable across executors
+
+You can't open a connection on the driver and broadcast it. Connections aren't picklable; the wrapper's per-process caches don't survive serialization either. Every executor (and in PySpark, every partition-function call) opens its own connection.
+
+## What the symptoms look like
+
+If you put the Python wrapper in stateful mode inside Spark executors, you'll typically see one or more of:
+
+- **High connection setup latency on first task per executor.** You're paying topology discovery on every cold executor.
+- **A burst of `SELECT … FROM aurora_replica_status` (or equivalent) queries against your cluster** at job start, one per executor.
+- **Background threads that briefly outlive their task** and produce log noise during executor shutdown.
+- **Zombie connections** if a partition task fails before `close()` runs and the monitor thread holds a reference. The cleaner eventually catches them, but RDS sees connection-count blips.
+- **`FailoverSuccessError` raised by the wrapper, then immediately swallowed by Spark's task-retry**, leaving you to wonder what value the wrapper added on that path.
+
+None of these are correctness bugs. They're all "the wrapper is doing work that doesn't help in this runtime."
+
+## What to use instead
+
+| Problem | Recommendation |
+|---|---|
+| Bulk read/write from PySpark to Aurora | **JDBC wrapper** via `--extra-jars`. The JDBC wrapper sits at the layer Spark drives bulk traffic through; its plugins fit per-executor JDBC connections naturally. |
+| Per-partition queries that need failover-aware error handling | **Python wrapper, [stateless mode](./UsingStatelessMode.md)**. Same exception contract; no background threads or caches. |
+| Per-partition queries where you'd rather not think about it | **RDS Proxy + plain driver (no wrapper)**. The proxy handles failover at the connection layer; you get connection pooling for free. You lose the typed exception contract and RW splitting. |
+| Driver-side control queries (watermarks, manifests, DDL) | **Python wrapper, stateful** (default). The driver is one long-lived process, which is exactly the shape the wrapper was built for. |
+
+## A hard rule and a soft rule
+
+**Hard rule:** never enable `host_monitoring` on connections that will live for less than ~30 seconds. The thread doesn't pay for itself.
+
+**Soft rule:** if you find yourself wanting to use `read_write_splitting` inside a partition task, you probably want two separate connections, or two separate jobs, instead.
+
+## "Then why does the Python wrapper exist for Glue at all?"
+
+Two reasons:
+
+1. **The Glue driver is a Python process.** Anything you run before/after `spark.read` / `df.write` runs on the driver, and the driver lives for the whole job. That's the natural home for the Python wrapper. Lookups, watermarks, manifests, DDL, post-load verification — all valid uses.
+
+2. **Glue Python Shell jobs exist.** They're a single-VM Python runtime with no Spark. Every feature of the Python wrapper works there exactly as designed. If your data-integration work fits in Python Shell (no need for distributed compute), use it and use the wrapper to its full extent.
+
+The mismatch is specifically with **Spark executor lifecycle**, not with Glue overall. Inside an executor, the Python wrapper is at the wrong layer; outside it (driver, Python Shell), the Python wrapper is exactly the right tool.
+
+## See also
+
+- [Stateless Mode](./UsingStatelessMode.md) — the supported way to use the Python wrapper in short-lived contexts
+- [Glue PySpark Guidance](./UsingFromGluePySpark.md) — concrete patterns for mixing Python wrapper (driver) and JDBC wrapper (bulk I/O)
+- [JDBC wrapper](https://github.com/aws/aws-advanced-jdbc-wrapper) — the right tool for executor-side bulk I/O

--- a/docs/using-the-python-wrapper/UsingFromGluePySpark.md
+++ b/docs/using-the-python-wrapper/UsingFromGluePySpark.md
@@ -1,0 +1,265 @@
+# Using the AWS Advanced Python Wrapper from AWS Glue PySpark
+
+This guide is opinionated. It tells you what works, what doesn't, and where to use the **JDBC** wrapper instead of the Python one.
+
+## Decision matrix: which wrapper, where
+
+| Workload in your Glue job | Use |
+|---|---|
+| **Bulk read** from Aurora into a DataFrame (`spark.read.format("jdbc")`) | **JDBC wrapper** via `--extra-jars` |
+| **Bulk write** from a DataFrame to Aurora (`df.write.format("jdbc")`) | **JDBC wrapper** via `--extra-jars` |
+| **Glue DynamicFrame** read/write to Aurora (`glueContext.create_dynamic_frame.from_options`) | **JDBC wrapper** (Glue passes the JDBC URL through) |
+| Driver-side queries: lookup a watermark, write a manifest, read config rows | **Python wrapper** on the driver |
+| Per-partition queries inside `mapPartitions` / `foreachPartition` | **Python wrapper in [stateless mode](./UsingStatelessMode.md)** |
+| Streaming jobs that hold a connection per microbatch | **Python wrapper, stateful** (microbatches are long enough) |
+
+The short version: **for bulk movement of data, use the JDBC wrapper**. The Python wrapper is for control-plane code on the driver and (in stateless mode) for short per-partition work. See [Not For Executors](./NotForExecutors.md) for why.
+
+## Setup
+
+### Option A — Bulk I/O via the JDBC wrapper (recommended for read/write at scale)
+
+In your Glue job parameters:
+
+```
+--extra-jars  s3://your-bucket/jars/aws-advanced-jdbc-wrapper-2.x.x.jar
+```
+
+Then in your job:
+
+```python
+df = (
+    spark.read.format("jdbc")
+    .option("url", "jdbc:aws-wrapper:postgresql://"
+                   "mycluster.cluster-xyz.us-east-1.rds.amazonaws.com:5432/mydb")
+    .option("driver", "software.amazon.jdbc.Driver")
+    .option("user", "appuser")
+    .option("password", get_secret())
+    .option("dbtable", "(select id, payload from events where ts > '2026-01-01') t")
+    # JDBC wrapper plugins
+    .option("wrapperPlugins", "failover,efm2,iam")
+    .option("wrapperDialect", "aurora-pg")
+    .load()
+)
+```
+
+This is the path Glue and Spark are designed around. Each executor gets its own JDBC connection; the wrapper's plugins fit the per-executor lifecycle naturally.
+
+### Option B — Driver-side control queries via the Python wrapper
+
+Useful for "look up a value before the run" / "write a manifest after the run" / DDL.
+
+```
+--additional-python-modules  aws-advanced-python-wrapper,psycopg[binary]
+```
+
+```python
+from aws_advanced_python_wrapper import AwsWrapperConnection
+import psycopg
+
+# Runs on the Spark driver — long-lived, one process. Stateful mode is fine here.
+conn = AwsWrapperConnection.connect(
+    psycopg.Connection.connect,
+    f"host={cluster_endpoint} dbname=mydb user=appuser",
+    plugins="failover,host_monitoring,iam",
+    wrapper_dialect="aurora-pg",
+    iam_region="us-east-1",
+)
+
+with conn.cursor() as cur:
+    cur.execute("SELECT max(processed_ts) FROM watermarks WHERE job=%s", (JOB_ID,))
+    watermark = cur.fetchone()[0]
+```
+
+### Option C — Per-partition queries via the Python wrapper in stateless mode
+
+Sometimes you need to look up something per row/partition that isn't worth a Spark join (e.g., per-partition external API calls plus a quick DB write). Use the Python wrapper in [stateless mode](./UsingStatelessMode.md):
+
+```
+--additional-python-modules  aws-advanced-python-wrapper,pg8000
+```
+
+```python
+from aws_advanced_python_wrapper import AwsWrapperConnection
+import pg8000
+
+STATELESS_PROPS = {
+    "plugins": "failover",
+    "cluster_topology_refresh_rate_ms": "0",
+    "monitoring_enabled": "false",
+    "failover_timeout_ms": "5000",
+}
+
+def write_partition(rows):
+    conn = AwsWrapperConnection.connect(
+        pg8000.dbapi.connect,
+        host=CLUSTER_ENDPOINT, database="mydb", user="appuser",
+        **STATELESS_PROPS,
+    )
+    try:
+        with conn.cursor() as cur:
+            for row in rows:
+                cur.execute("INSERT INTO sink (id, payload) VALUES (%s, %s)",
+                            (row.id, row.payload))
+        conn.commit()
+    finally:
+        conn.close()
+
+df.foreachPartition(write_partition)
+```
+
+`pg8000` is a pure-Python driver — no native build, easiest to ship via `--additional-python-modules`. Use `psycopg[binary]` if you need higher throughput and your wheel set tolerates the native dep.
+
+## Configuration that matters in Glue
+
+### Job role → DB user (IAM auth)
+
+Don't put DB passwords in job parameters. Use the `iam` plugin and let your Glue job's IAM role become the DB principal:
+
+```python
+plugins="failover,iam"
+iam_region="us-east-1"
+# user is the DB user mapped to the IAM role; no password needed
+```
+
+The Glue job role needs `rds-db:connect` on the resource ARN of your DB user.
+
+### Secrets, if you must
+
+If you can't use IAM auth, fetch from Secrets Manager on the driver and broadcast — never include the password in `--default-arguments`:
+
+```python
+secret = boto3.client("secretsmanager").get_secret_value(SecretId="...")
+broadcast_pw = sc.broadcast(json.loads(secret["SecretString"])["password"])
+```
+
+### Pick the right cluster endpoint
+
+- **Writer cluster endpoint** for jobs that write or need read-after-write.
+- **Reader cluster endpoint** for read-only bulk loads — DNS load-balances across readers, and per-executor connections will spread out.
+- **Custom endpoints** if you want to pin to a specific reader subset.
+
+## Failover handling in PySpark
+
+The exception contract is the same as anywhere else in the Python wrapper, but **the unit of retry is the Spark task**, not your Python loop. Don't try to retry a transaction inside `mapPartitions` — let it fail, and configure Spark to retry the task:
+
+```python
+spark.conf.set("spark.task.maxFailures", "4")
+```
+
+Inside the partition function, surface failover errors as exceptions:
+
+```python
+from aws_advanced_python_wrapper.errors import (
+    FailoverSuccessError, FailoverFailedError, TransactionStateUnknownError,
+)
+
+def write_partition(rows):
+    conn = open_stateless()
+    try:
+        ...
+        conn.commit()
+    except (FailoverSuccessError, FailoverFailedError):
+        # Let the task fail. Spark retries on a different executor; the new
+        # connection resolves to the new writer via DNS.
+        raise
+    except TransactionStateUnknownError:
+        # COMMIT may or may not have applied. Make your write idempotent
+        # (INSERT ... ON CONFLICT, MERGE, partitioned by run-id) and re-raise
+        # to let Spark retry.
+        raise
+    finally:
+        conn.close()
+```
+
+**Make every per-partition write idempotent.** Spark task retry is at-least-once; combined with `TransactionStateUnknownError`, you can see the same partition apply twice. Idempotency at the SQL level (`ON CONFLICT DO NOTHING`, `MERGE`, dedup by run-id) is the only safe answer.
+
+## Things that don't work the way you'd hope
+
+- **Sharing one Python wrapper connection across executors.** You can't. Connections are not picklable; even if they were, the wrapper's caches are per-process. Open per-executor (or per-partition) connections.
+- **`read_write_splitting` plugin in `mapPartitions`.** The plugin's value is reusing a single connection for both roles over time — but partition tasks are short-lived. You're paying its overhead for none of its benefit.
+- **`host_monitoring` plugin per partition.** Spawns a thread that gets reaped before it does anything useful. Disable it in stateless mode.
+- **Setting `cluster_topology_refresh_rate_ms` low to "react faster" in PySpark.** Each executor has its own cache; lowering the rate just multiplies refresh queries against your cluster. If you want fast detection, use RDS Proxy.
+
+## RDS Proxy as an alternative
+
+For PySpark workloads where stateless-mode exception handling is more contract than you need, point Spark at RDS Proxy instead of the cluster. The proxy handles failover at the connection layer and Spark sees a connection drop / reconnect. You lose RW splitting and the typed exception contract; you gain a runtime model that matches Spark's lifecycle.
+
+```
+spark.read.format("jdbc")
+  .option("url", "jdbc:postgresql://my-proxy.proxy-xyz.us-east-1.rds.amazonaws.com:5432/mydb")
+```
+
+This works fine without either wrapper. Pick this path if your team prefers fewer moving parts.
+
+## Sample job: end-to-end
+
+```python
+import sys, json, boto3
+from awsglue.utils import getResolvedOptions
+from awsglue.context import GlueContext
+from pyspark.context import SparkContext
+from aws_advanced_python_wrapper import AwsWrapperConnection
+from aws_advanced_python_wrapper.errors import FailoverSuccessError
+import psycopg
+
+args = getResolvedOptions(sys.argv, ["JOB_NAME", "CLUSTER_ENDPOINT"])
+sc = SparkContext()
+glueContext = GlueContext(sc)
+spark = glueContext.spark_session
+
+CLUSTER = args["CLUSTER_ENDPOINT"]
+
+# 1. Driver-side: read the watermark via the Python wrapper (stateful — long-lived).
+def read_watermark():
+    conn = AwsWrapperConnection.connect(
+        psycopg.Connection.connect,
+        f"host={CLUSTER} dbname=mydb user=appuser",
+        plugins="failover,iam",
+        wrapper_dialect="aurora-pg",
+        iam_region="us-east-1",
+    )
+    try:
+        with conn.cursor() as cur:
+            cur.execute("SELECT max(ts) FROM watermarks WHERE job=%s",
+                        (args["JOB_NAME"],))
+            return cur.fetchone()[0]
+    finally:
+        conn.close()
+
+watermark = read_watermark()
+
+# 2. Bulk read from Aurora via the JDBC wrapper.
+df = (
+    spark.read.format("jdbc")
+    .option("url", f"jdbc:aws-wrapper:postgresql://{CLUSTER}:5432/mydb")
+    .option("driver", "software.amazon.jdbc.Driver")
+    .option("user", "appuser")
+    .option("dbtable", f"(SELECT * FROM events WHERE ts > '{watermark}') t")
+    .option("wrapperPlugins", "failover,efm2,iam")
+    .option("wrapperDialect", "aurora-pg")
+    .load()
+)
+
+# 3. Process and write back via the JDBC wrapper.
+processed = df.transform(my_transform)
+
+(
+    processed.write.format("jdbc")
+    .option("url", f"jdbc:aws-wrapper:postgresql://{CLUSTER}:5432/mydb")
+    .option("driver", "software.amazon.jdbc.Driver")
+    .option("user", "appuser")
+    .option("dbtable", "events_out")
+    .option("wrapperPlugins", "failover,efm2,iam")
+    .mode("append")
+    .save()
+)
+```
+
+The Python wrapper sits where it's most useful (the driver). The JDBC wrapper sits where bulk movement actually happens (the executors).
+
+## See also
+
+- [Stateless Mode](./UsingStatelessMode.md)
+- [Not For Executors](./NotForExecutors.md)
+- [JDBC wrapper documentation](https://github.com/aws/aws-advanced-jdbc-wrapper)

--- a/docs/using-the-python-wrapper/UsingStatelessMode.md
+++ b/docs/using-the-python-wrapper/UsingStatelessMode.md
@@ -1,0 +1,137 @@
+# Using Stateless Mode
+
+## What it is
+
+Stateless mode is a configuration of the AWS Advanced Python Wrapper that strips out the long-lived background machinery — host monitoring threads, topology caches, dialect probing, async upgrade attempts — and keeps only the parts that work for short-lived, per-task connections:
+
+- The DB-API connection wrapper itself
+- Failover **error mapping** (the wrapper still raises `FailoverSuccessError` / `FailoverFailedError` / `TransactionStateUnknownError` when it sees the cluster behave that way during a single connection's lifetime)
+- IAM authentication (token generation per-connect)
+- TLS / driver-protocol passthrough
+
+It does **not** give you transparent reconnection across failover, RW splitting, or proactive host health monitoring. Use it when those features cost more than they're worth — e.g., when your runtime opens a connection, runs one transaction, and closes it.
+
+## When to use it
+
+Use stateless mode when **all** of these are true:
+
+- Connection lifetime is measured in seconds, not minutes (Spark partition tasks, Lambda invocations without container reuse, Glue PySpark `mapPartitions`, Step Functions iterations).
+- You don't share a single connection across many transactions.
+- You don't need RW splitting (you connect to writer or reader, not both, on the same connection).
+- You're willing to handle reconnection at a higher layer (Spark task retry, Step Functions retry, your own loop).
+
+Use the **default (stateful) configuration** when:
+
+- The connection lives for minutes or hours and serves many transactions.
+- You want host monitoring to detect a dead writer faster than your TCP keepalives will.
+- You use the `read_write_splitting` plugin to swap reader/writer on the same logical connection.
+
+## How to enable it
+
+Stateless mode is a curated set of properties — no single switch. The recipe:
+
+```python
+from aws_advanced_python_wrapper import AwsWrapperConnection
+import psycopg
+
+STATELESS_PROPS = {
+    # Plugins: only failover error mapping. No host_monitoring, no read_write_splitting.
+    "plugins": "failover",
+
+    # Don't spawn topology refresh threads.
+    "cluster_topology_refresh_rate_ms": "0",
+
+    # Disable the host availability tracker's background work.
+    "monitoring_enabled": "false",
+
+    # Failover behavior: surface errors to the caller; don't loop trying to find a writer.
+    "failover_mode": "strict-writer",
+    "failover_timeout_ms": "5000",       # short — let the orchestrator retry
+    "failover_writer_reconnect_interval_ms": "1000",
+    "failover_reader_connect_timeout_ms": "5000",
+}
+
+conn = AwsWrapperConnection.connect(
+    psycopg.Connection.connect,
+    "host=mycluster.cluster-xyz.us-east-1.rds.amazonaws.com "
+    "dbname=mydb user=appuser",
+    **STATELESS_PROPS,
+)
+```
+
+## What you get and what you don't
+
+| Feature | Stateful (default) | Stateless |
+|---|---|---|
+| Failover *error contract* (the four exceptions) | Yes | Yes |
+| Transparent reconnection across failover (same connection object survives) | Yes | No — connection is closed; caller retries |
+| Host monitoring (background liveness probes) | Yes | No |
+| Read/write splitting on the same connection | Yes | No |
+| Topology cache shared across operations on the same connection | Yes | Per-connect only |
+| IAM auth | Yes | Yes |
+| Per-connect overhead | Higher (cache warm-up, monitor thread spawn) | Lower |
+| Background thread count | 1+ per connection | 0 |
+| Suitable for `mapPartitions` / per-task connections | No | Yes |
+
+## Error handling in stateless mode
+
+The same exception contract applies, but the *meaning* shifts. Without a host monitor or topology refresh, the wrapper detects failover when a query fails with a state that implies the writer is gone (read-only error, connection lost, etc.). It maps that to `FailoverSuccessError` / `FailoverFailedError` / `TransactionStateUnknownError` exactly as it does in stateful mode.
+
+The difference: in stateless mode the wrapper does **not** transparently reconnect you to the new writer on the same connection object. The connection is closed. Your caller is expected to:
+
+```python
+from aws_advanced_python_wrapper.errors import (
+    FailoverSuccessError,
+    FailoverFailedError,
+    TransactionStateUnknownError,
+)
+
+def run_with_retry(work, retries=3):
+    for attempt in range(retries):
+        conn = open_connection()  # fresh wrapper instance
+        try:
+            with conn.cursor() as cur:
+                work(cur)
+            conn.commit()
+            return
+        except FailoverSuccessError:
+            # Connection is dead. Open a new one — DNS/topology will route to new writer.
+            continue
+        except TransactionStateUnknownError:
+            if work.is_idempotent:
+                continue
+            raise
+        except FailoverFailedError:
+            raise  # let the orchestrator decide
+        finally:
+            try:
+                conn.close()
+            except Exception:
+                pass
+    raise RuntimeError("transaction did not complete after retries")
+```
+
+In a Spark partition task, the equivalent is to let the task fail and Spark's `task.maxFailures` retry it on a different executor. The fresh executor opens a fresh connection, which resolves to the new writer via DNS.
+
+## Limitations
+
+- **No proactive failure detection.** Stateless mode learns about failover only when a query fails. If your connection is idle when failover happens, the next query absorbs the latency hit.
+- **No RW splitting.** If you set `plugins=read_write_splitting,failover` you re-introduce the state machine that stateless mode is trying to avoid. Don't mix them.
+- **No connection-internal reconnect.** A `FailoverSuccessError` from stateless mode means "this connection is done." Open a new one.
+- **Per-task connection overhead.** Each fresh connect re-runs IAM token generation (if used), TCP handshake, TLS handshake, and dialect detection. For very short tasks (<1s of work) this overhead may dominate. Consider RDS Proxy in front of the cluster — it amortizes connection setup and handles failover at its own layer.
+
+## Combining with RDS Proxy
+
+For Glue PySpark and similar short-task workloads, the most reliable production setup is:
+
+```
+PySpark executor → aws-advanced-python-wrapper (stateless) → RDS Proxy → Aurora
+```
+
+RDS Proxy gives you connection pooling and transparent failover at the proxy layer; the wrapper above it gives you the typed exception contract for your application code. You lose RW splitting, but you weren't getting it in stateless mode anyway.
+
+## See also
+
+- [Glue PySpark Guidance](./UsingFromGluePySpark.md)
+- [Not For Executors](./NotForExecutors.md)
+- [Failover plugin reference](./using-plugins/UsingTheFailoverPlugin.md)

--- a/docs/using-the-python-wrapper/UsingThePythonWrapper.md
+++ b/docs/using-the-python-wrapper/UsingThePythonWrapper.md
@@ -109,6 +109,14 @@ The AWS Advanced Python Wrapper has several built-in plugins that are available 
 In addition to the built-in plugins, you can also create custom plugins more suitable for your needs.
 For more information, see [Custom Plugins](../development-guide/LoadablePlugins.md#using-custom-plugins).
 
+## Runtime Guidance
+
+The wrapper's default (stateful) configuration assumes a long-lived process that holds a small number of connections for many transactions. For short-lived runtimes — Spark executors, per-task connections, jobs that open and close a connection per invocation — see:
+
+- [Stateless Mode](./UsingStatelessMode.md) — strip background threads and caches; keep the failover exception contract.
+- [Using From Glue PySpark](./UsingFromGluePySpark.md) — opinionated guide for mixing the Python wrapper (driver-side) with the JDBC wrapper (executor bulk I/O).
+- [Not For Executors](./NotForExecutors.md) — when the Python wrapper is at the wrong layer, what symptoms to expect, and what to use instead.
+
 ## Logging
 
 The AWS Advanced Python Wrapper uses the standard [Python logging module](https://docs.python.org/3/library/logging.html) to log information. To configure logging for the AWS Advanced Python Wrapper, refer to [this section of the Python logging docs](https://docs.python.org/3/howto/logging.html#configuring-logging). Please note the following:


### PR DESCRIPTION
### Description

Add three runtime-shape guides for users running the wrapper outside the long-lived process model the default config assumes:

- UsingStatelessMode.md: property recipe to disable host monitoring and topology refresh while keeping the failover exception contract; for per-task / per-invocation connections.
- UsingFromGluePySpark.md: opinionated decision matrix steering bulk I/O to the JDBC wrapper and reserving the Python wrapper for driver-side control queries and stateless per-partition use.
- NotForExecutors.md: explains why the default plugin set (host_monitoring, read_write_splitting, transparent reconnect) doesn't fit Spark executor lifecycle, what symptoms to expect, and what to use instead.

Cross-link the three from a new Runtime Guidance section in UsingThePythonWrapper.md so they're discoverable from the index.


### By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
