### PR TITLE
fix: move PoolKey to utils/pool_key so the async provider can share it

### DIFF
--- a/aws_advanced_python_wrapper/aio/pooled_connection_provider.py
+++ b/aws_advanced_python_wrapper/aio/pooled_connection_provider.py
@@ -36,9 +36,9 @@ from aws_advanced_python_wrapper.errors import AwsWrapperError
 from aws_advanced_python_wrapper.host_selector import (
     HighestWeightHostSelector, HostSelector, RandomHostSelector,
     RoundRobinHostSelector, WeightedRandomHostSelector)
-from aws_advanced_python_wrapper.sql_alchemy_connection_provider import PoolKey
 from aws_advanced_python_wrapper.utils.log import Logger
 from aws_advanced_python_wrapper.utils.messages import Messages
+from aws_advanced_python_wrapper.utils.pool_key import PoolKey
 from aws_advanced_python_wrapper.utils.properties import (Properties,
                                                           WrapperProperties)
 from aws_advanced_python_wrapper.utils.rds_url_type import RdsUrlType
@@ -425,7 +425,6 @@ class AsyncPooledConnectionProvider(AsyncCanReleaseResources):
 
 __all__ = [
     "AsyncPooledConnectionProvider",
-    "PoolKey",
     # Private but re-exported for tests:
     "_AsyncPool",
     "_PooledAsyncConnectionProxy",

--- a/aws_advanced_python_wrapper/sql_alchemy_connection_provider.py
+++ b/aws_advanced_python_wrapper/sql_alchemy_connection_provider.py
@@ -30,6 +30,7 @@ from aws_advanced_python_wrapper.host_selector import (
     RoundRobinHostSelector, WeightedRandomHostSelector)
 from aws_advanced_python_wrapper.plugin import CanReleaseResources
 from aws_advanced_python_wrapper.utils.messages import Messages
+from aws_advanced_python_wrapper.utils.pool_key import PoolKey
 from aws_advanced_python_wrapper.utils.properties import (Properties,
                                                           WrapperProperties)
 from aws_advanced_python_wrapper.utils.rds_url_type import RdsUrlType
@@ -188,29 +189,3 @@ class SqlAlchemyPooledConnectionProvider(ConnectionProvider, CanReleaseResources
                 # Swallow exception, connections may already be dead
                 pass
         SqlAlchemyPooledConnectionProvider._database_pools.clear()
-
-
-class PoolKey:
-    def __init__(self, url: str, extra_key: Optional[str] = None):
-        self._url = url
-        self._extra_key = extra_key
-
-    def __eq__(self, other):
-        if isinstance(other, type(self)):
-            return self.__members() == other.__members()
-        else:
-            return False
-
-    def __hash__(self):
-        return hash(self.__members())
-
-    def __members(self) -> Tuple[str, Optional[str]]:
-        return self._url, self._extra_key
-
-    @property
-    def url(self):
-        return self._url
-
-    @property
-    def extra_key(self):
-        return self._extra_key

--- a/aws_advanced_python_wrapper/utils/pool_key.py
+++ b/aws_advanced_python_wrapper/utils/pool_key.py
@@ -1,0 +1,50 @@
+#  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License").
+#  You may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#  http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+"""Cache key shared by the sync and async internal connection pool providers.
+
+This lives in its own module, free of any pool implementation imports, so that
+the async provider can key its pools identically without taking a dependency on
+SQLAlchemy (which the sync provider requires but the async provider does not).
+"""
+
+from __future__ import annotations
+
+from typing import Optional, Tuple
+
+
+class PoolKey:
+    def __init__(self, url: str, extra_key: Optional[str] = None):
+        self._url = url
+        self._extra_key = extra_key
+
+    def __eq__(self, other):
+        if isinstance(other, type(self)):
+            return self.__members() == other.__members()
+        else:
+            return False
+
+    def __hash__(self):
+        return hash(self.__members())
+
+    def __members(self) -> Tuple[str, Optional[str]]:
+        return self._url, self._extra_key
+
+    @property
+    def url(self):
+        return self._url
+
+    @property
+    def extra_key(self):
+        return self._extra_key

--- a/tests/unit/test_aio_pooled_connection_provider.py
+++ b/tests/unit/test_aio_pooled_connection_provider.py
@@ -20,12 +20,12 @@ from unittest.mock import AsyncMock, MagicMock
 import pytest
 
 from aws_advanced_python_wrapper.aio.pooled_connection_provider import (
-    AsyncPooledConnectionProvider, PoolKey, _AsyncPool,
-    _PooledAsyncConnectionProxy)
+    AsyncPooledConnectionProvider, _AsyncPool, _PooledAsyncConnectionProxy)
 from aws_advanced_python_wrapper.aio.storage.sliding_expiration_cache_async import \
     AsyncSlidingExpirationCache
 from aws_advanced_python_wrapper.errors import AwsWrapperError
 from aws_advanced_python_wrapper.hostinfo import HostInfo, HostRole
+from aws_advanced_python_wrapper.utils.pool_key import PoolKey
 from aws_advanced_python_wrapper.utils.properties import (Properties,
                                                           WrapperProperties)
 

--- a/tests/unit/test_pool_key.py
+++ b/tests/unit/test_pool_key.py
@@ -12,7 +12,7 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
-from aws_advanced_python_wrapper.sql_alchemy_connection_provider import PoolKey
+from aws_advanced_python_wrapper.utils.pool_key import PoolKey
 
 
 def test_eq():

--- a/tests/unit/test_sql_alchemy_pooled_connection_provider.py
+++ b/tests/unit/test_sql_alchemy_pooled_connection_provider.py
@@ -17,8 +17,9 @@ import pytest
 
 from aws_advanced_python_wrapper.errors import AwsWrapperError
 from aws_advanced_python_wrapper.hostinfo import HostInfo, HostRole
-from aws_advanced_python_wrapper.sql_alchemy_connection_provider import (
-    PoolKey, SqlAlchemyPooledConnectionProvider)
+from aws_advanced_python_wrapper.sql_alchemy_connection_provider import \
+    SqlAlchemyPooledConnectionProvider
+from aws_advanced_python_wrapper.utils.pool_key import PoolKey
 from aws_advanced_python_wrapper.utils.properties import (Properties,
                                                           WrapperProperties)
 from aws_advanced_python_wrapper.utils.storage.sliding_expiration_cache import \


### PR DESCRIPTION
### Description

Moves `PoolKey` out of `sql_alchemy_connection_provider.py` into a new dependency-free module, `aws_advanced_python_wrapper/utils/pool_key.py`.

`AsyncPooledConnectionProvider` keys its internal pools with the same `PoolKey` as the sync provider, but it previously had to reach into `sql_alchemy_connection_provider` to get it. That module imports `sqlalchemy` at module scope, and SQLAlchemy is a dev-only dependency of this package — so importing the async pooled connection provider pulled in SQLAlchemy and would raise `ModuleNotFoundError` for anyone using the async internal connection pool without SQLAlchemy installed. The async pooled provider itself has no use for SQLAlchemy; it manages its own async pools.

`PoolKey` is a two-field cache key (`url`, `extra_key`) with no pool-implementation dependencies, so the new module imports nothing beyond `typing`. Both providers now import it from the canonical location, and the class itself is unchanged — this is a pure move plus import updates, with no behavior change.

The relocation also drops the re-export shims that briefly stood in for the old import paths. `PoolKey` is an internal cache key: it is not exported from `aws_advanced_python_wrapper/__init__.py`, is not referenced anywhere in `docs/`, and is not part of the documented public API, so aliases in the two provider modules only advertise a second and third place the class appears to live. Note that `from aws_advanced_python_wrapper.sql_alchemy_connection_provider import PoolKey` still resolves regardless, since that module imports the name for its own use — anyone who reached for the old path keeps working without a documented alias.

### Changes

- Add `aws_advanced_python_wrapper/utils/pool_key.py` holding `PoolKey`, with a module docstring explaining why it stands alone.
- `sql_alchemy_connection_provider.py`: import `PoolKey` from the new module; drop the class definition and the trailing `__all__` block (the sync modules in this package do not otherwise declare `__all__`).
- `aio/pooled_connection_provider.py`: import `PoolKey` from the new module instead of from the SQLAlchemy provider, and drop it from `__all__`.
- Tests: `test_pool_key.py`, `test_sql_alchemy_pooled_connection_provider.py`, and `test_aio_pooled_connection_provider.py` import `PoolKey` from the canonical path.

### By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
